### PR TITLE
Add options to avoid disrupting OTA updates

### DIFF
--- a/recovery/root/etc/twrp.fstab
+++ b/recovery/root/etc/twrp.fstab
@@ -9,9 +9,12 @@
 /efs2         emmc          /dev/block/bootdevice/by-name/modemst2       flags=backup=1;subpartitionof=/efs1
 /persist      ext4          /dev/block/bootdevice/by-name/persist        flags=backup=1;display="Persist"
 /firmware     ext4          /dev/block/bootdevice/by-name/modem          flags=backup=1;display="Firmware";slotselect;fsflags=nosuid,nodev
+/firmware_img emmc          /dev/block/bootdevice/by-name/modem          flags=backup=1;display="Firmware image";slotselect
 /fsg          emmc          /dev/block/bootdevice/by-name/fsg            flags=backup=1;display="FSG";slotselect
 /oem          ext4          /dev/block/bootdevice/by-name/oem            flags=backup=1;display="OEM";slotselect;wipeingui
+/oem_image    emmc          /dev/block/bootdevice/by-name/oem            flags=backup=1;display="OEM image";slotselect
 /dsp          ext4          /dev/block/bootdevice/by-name/dsp            flags=backup=1;display="DSP";slotselect
+/dsp_image    emmc          /dev/block/bootdevice/by-name/dsp            flags=backup=1;display="DSP image";slotselect
 /metadata     emmc          /dev/block/bootdevice/by-name/metadata
 /misc         emmc          /dev/block/bootdevice/by-name/misc
 /logo         emmc          /dev/block/bootdevice/by-name/logo           flags=backup=1;display="Boot Logo";slotselect;flashimg=1


### PR DESCRIPTION
Stock ROM OTA updates perform block diff patches against the partitions `modem`, `oem`, and `dsp`. If these are listed as `ext4` for backup, TWRP mounts them read-write during the backup process. Doing this “damages” the partitions and prevents subsequent OTA updates from completing successfully.

This commit adds backup options for these partitions that will not disrupt future stock ROM OTA updates.